### PR TITLE
Edge router selection

### DIFF
--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -1,0 +1,16 @@
+name: CI build
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Build with Gradle
+        run: ./gradlew check

--- a/ziti/src/main/kotlin/org/openziti/api/types.kt
+++ b/ziti/src/main/kotlin/org/openziti/api/types.kt
@@ -36,7 +36,7 @@ internal class SessionReq(val serviceId: String, val type: SessionType = Session
 
 data class ControllerVersion(val buildDate: String, val revision: String, val runtimeVersion: String, val version: String)
 internal class Login(val username: String, val password: String)
-internal class ApiSession(val token: String, val identity: Identity?)
+internal class ApiSession(val id: String, val token: String, val identity: Identity?)
 
 data class ServiceDNS(val hostname: String, val port: Int)
 data class Service internal constructor(
@@ -55,7 +55,7 @@ data class Service internal constructor(
 internal data class EdgeRouter(val name: String, val hostname: String, val urls: Map<String, String>)
 
 internal data class Session(val id: String, val token: String, val service: Id, val type: SessionType,
-                            var edgeRouters: Array<EdgeRouter>) {
+                            var edgeRouters: Array<EdgeRouter>?) {
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/ziti/src/main/kotlin/org/openziti/identity/Identity.kt
+++ b/ziti/src/main/kotlin/org/openziti/identity/Identity.kt
@@ -32,8 +32,6 @@ interface Identity {
     fun name(): String
     fun sslContext(): SSLContext
     fun trustManager(): X509TrustManager
-
-    var sessionToken: String?
 }
 
 internal class KeyStoreIdentity(private val ks: KeyStore, alias: String, pw: CharArray = charArrayOf()) : Identity {
@@ -76,6 +74,4 @@ internal class KeyStoreIdentity(private val ks: KeyStore, alias: String, pw: Cha
     override fun sslContext(): SSLContext = ssl
 
     override fun trustManager(): X509TrustManager = tm
-
-    override var sessionToken: String? = null
 }

--- a/ziti/src/main/kotlin/org/openziti/net/Channel.kt
+++ b/ziti/src/main/kotlin/org/openziti/net/Channel.kt
@@ -24,6 +24,7 @@ import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.flow
 import org.openziti.Errors
 import org.openziti.ZitiException
+import org.openziti.api.ApiSession
 import org.openziti.identity.Identity
 import org.openziti.util.Logged
 import org.openziti.util.ZitiLog
@@ -227,15 +228,13 @@ internal class Channel(val addr: String, val peer: Transport) : Closeable, Corou
     override fun toString(): String = "Channel[$peer]"
 
     companion object {
-        suspend fun Dial(addr: String, id: Identity): Channel {
+        suspend fun Dial(addr: String, id: Identity, apiSession: ApiSession): Channel {
             try {
-                val token = id.sessionToken ?: throw IllegalStateException("no session token for connection")
-
                 val peer = Transport.dial(addr, id.sslContext())
                 val ch = Channel(addr, peer)
 
                 val helloMsg = Message.newHello(id.name()).apply {
-                    setHeader(ZitiProtocol.Header.SessionToken, token)
+                    setHeader(ZitiProtocol.Header.SessionToken, apiSession.token)
                 }
 
                 val reply = ch.SendAndWait(helloMsg)

--- a/ziti/src/main/kotlin/org/openziti/net/Channel.kt
+++ b/ziti/src/main/kotlin/org/openziti/net/Channel.kt
@@ -87,6 +87,17 @@ internal class Channel(val addr: String, val peer: Transport) : Closeable, Corou
     }
 
     override fun close() {
+
+        for (v in waiters) {
+            v.value.completeExceptionally(CancellationException())
+        }
+        waiters.clear()
+
+        for (v in synchers) {
+            v.value.completeExceptionally(CancellationException())
+        }
+        synchers.clear()
+
         for (l in closeListeners) {
             l()
         }

--- a/ziti/src/main/kotlin/org/openziti/net/Transport.kt
+++ b/ziti/src/main/kotlin/org/openziti/net/Transport.kt
@@ -16,7 +16,9 @@
 
 package org.openziti.net
 
+import kotlinx.coroutines.CompletableDeferred
 import org.openziti.net.nio.AsyncTLSChannel
+import org.openziti.net.nio.DeferredHandler
 import org.openziti.util.Logged
 import org.openziti.util.ZitiLog
 import java.io.Closeable
@@ -36,13 +38,16 @@ import kotlin.coroutines.suspendCoroutine
 internal interface Transport : Closeable {
 
     companion object {
-        fun dial(address: String, ssl: SSLContext): Transport {
+        suspend fun dial(address: String, ssl: SSLContext): Transport {
             val url = URI.create(address)
-            return TLS(url.host, url.port, ssl)
+            val tls = TLS(url.host, url.port, ssl)
+            tls.connect()
+            return tls
         }
     }
 
     fun isClosed(): Boolean
+    suspend fun connect()
 
     suspend fun write(buf: ByteBuffer)
     suspend fun read(buf: ByteBuffer, full: Boolean = true): Int
@@ -53,11 +58,16 @@ internal interface Transport : Closeable {
 
     class TLS(host: String, port: Int, sslContext: SSLContext) : Transport, Logged by ZitiLog("ziti-tls") {
         val socket: AsynchronousSocketChannel
-
+        val addr = InetSocketAddress(InetAddress.getByName(host), port)
         init {
             d { "connecting to $host:$port on t[${Thread.currentThread().name}" }
             socket = AsyncTLSChannel(sslContext)
-            socket.connect(InetSocketAddress(InetAddress.getByName(host), port)).get()
+        }
+
+        override suspend fun connect() {
+            val done = CompletableDeferred<Void>()
+            socket.connect(addr, done, DeferredHandler())
+            done.await()
         }
 
         override suspend fun write(buf: ByteBuffer):Unit = suspendCoroutine {

--- a/ziti/src/main/kotlin/org/openziti/net/Transport.kt
+++ b/ziti/src/main/kotlin/org/openziti/net/Transport.kt
@@ -105,6 +105,10 @@ internal interface Transport : Closeable {
         }
 
         override fun isClosed(): Boolean = !socket.isOpen
+
+        override fun toString(): String {
+            return "TLS:${socket.remoteAddress}"
+        }
     }
 
 }

--- a/ziti/src/main/kotlin/org/openziti/net/ZitiServerSocketChannel.kt
+++ b/ziti/src/main/kotlin/org/openziti/net/ZitiServerSocketChannel.kt
@@ -18,8 +18,8 @@ package org.openziti.net
 
 import com.goterl.lazycode.lazysodium.utils.Key
 import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.ClosedReceiveChannelException
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import org.openziti.ZitiAddress
 import org.openziti.api.SessionType
@@ -121,7 +121,7 @@ internal class ZitiServerSocketChannel(val ctx: ZitiContextImpl): AsynchronousSe
         if (state == State.closed) throw ClosedChannelException()
         if (state != State.bound) throw NotYetBoundException()
 
-        ctx.async {
+        ctx.launch {
             try {
                 val req = incoming.receive()
 

--- a/ziti/src/main/kotlin/org/openziti/net/ZitiSocketChannel.kt
+++ b/ziti/src/main/kotlin/org/openziti/net/ZitiSocketChannel.kt
@@ -119,6 +119,10 @@ internal class ZitiSocketChannel(internal val ctx: ZitiContextImpl):
 
             val ns = ctx.getNetworkSession(remote.name, SessionType.Dial)
             channel = ctx.getChannel(ns)
+            channel.onClose {
+                state.set(State.closed)
+                receiveQueue.cancel()
+            }
             connId = channel.registerReceiver(this@ZitiSocketChannel)
 
             val connectMsg = Message(ZitiProtocol.ContentType.Connect, ns.token.toByteArray(UTF_8))

--- a/ziti/src/test/kotlin/org/openziti/net/TransportTest.kt
+++ b/ziti/src/test/kotlin/org/openziti/net/TransportTest.kt
@@ -28,9 +28,9 @@ class TransportTest {
 
     @Test
     fun testHTTP() {
-        val t = Transport.dial("tls://httpbin.org:443", SSLContext.getDefault())
-
         runBlocking {
+            val t = Transport.dial("tls://httpbin.org:443", SSLContext.getDefault())
+
             val req = """POST /anything HTTP/1.1
 Accept: */*
 Connection: keep-alive
@@ -47,8 +47,7 @@ User-Agent: ziti/1.0.2
             println(resp)
             val lines = resp.toString().reader().readLines()
             assertThat(lines[0], CoreMatchers.startsWith("HTTP/1.1 200 OK"))
-
+            t.close()
         }
-        t.close()
     }
 }


### PR DESCRIPTION
multiple improvements
* keep edge routers connected as they show up in sessions
* implement Channel2 latency checks
* use latency for edge router selection
* improve `/services` and `/session` API with paging