### PR TITLE
Controller HTTP/2 support

### DIFF
--- a/samples/terminators-sample/src/main/kotlin/org/openziti/sample/terminators/Main.kt
+++ b/samples/terminators-sample/src/main/kotlin/org/openziti/sample/terminators/Main.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 NetFoundry, Inc.
+ * Copyright (c) 2018-2021 NetFoundry, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,9 +17,7 @@
 package org.openziti.sample.terminators
 
 import kotlinx.coroutines.*
-import kotlinx.coroutines.flow.filter
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.*
 import org.openziti.Ziti
 import org.openziti.ZitiAddress
 import org.openziti.ZitiContext

--- a/ziti/src/main/kotlin/org/openziti/net/nio/AsyncTLSChannel.kt
+++ b/ziti/src/main/kotlin/org/openziti/net/nio/AsyncTLSChannel.kt
@@ -421,7 +421,7 @@ class AsyncTLSChannel(
     private fun readInternal() = GlobalScope.launch(Dispatchers.IO) {
         d("start reading loop()")
         kotlin.runCatching {
-            val sslInBuf = ByteBuffer.allocateDirect(SSL_BUFFER_SIZE * 2).flip()
+            val sslInBuf = ByteBuffer.allocateDirect(SSL_BUFFER_SIZE * 2).apply { flip() }
             var plainBuf = ByteBuffer.allocate(SSL_BUFFER_SIZE)
             var res: SSLEngineResult
             do {

--- a/ziti/src/main/kotlin/org/openziti/net/nio/AsyncTLSChannel.kt
+++ b/ziti/src/main/kotlin/org/openziti/net/nio/AsyncTLSChannel.kt
@@ -481,7 +481,7 @@ class AsyncTLSChannel(
                     d { "hsbuf = $hsBuf" }
                     transport.writeSuspend(hsBuf)
                 }
-                NEED_UNWRAP, NEED_UNWRAP_AGAIN -> {
+                NEED_UNWRAP -> {
                     while (engine.handshakeStatus == NEED_UNWRAP) {
                         if (engine.unwrap(inBuf, hsBuf).status == BUFFER_UNDERFLOW)
                             return

--- a/ziti/src/main/kotlin/org/openziti/net/nio/AsyncTLSChannelSocket.kt
+++ b/ziti/src/main/kotlin/org/openziti/net/nio/AsyncTLSChannelSocket.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020 NetFoundry, Inc.
+ * Copyright (c) 2018-2021 NetFoundry, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,6 +57,8 @@ class AsyncTLSChannelSocket(transport: AsynchronousSocketChannel, host: String, 
         listeners.remove(l)?.cancel(false)
     }
 
+    override fun setSSLParameters(params: SSLParameters) = asyncTls.setSSLParameters(params)
+
     override fun getEnabledCipherSuites(): Array<String> = asyncTls.getEnabledCipherSuites()
     override fun getSupportedCipherSuites(): Array<String> = asyncTls.getSupportedCipherSuites()
     override fun setEnabledCipherSuites(p: Array<String>) = asyncTls.setEnabledCipherSuites(p)
@@ -64,7 +66,7 @@ class AsyncTLSChannelSocket(transport: AsynchronousSocketChannel, host: String, 
     override fun getSupportedProtocols(): Array<String> = asyncTls.getSupportedProtocols()
     override fun setEnabledProtocols(p: Array<String>) = asyncTls.setEnabledProtocols(p)
     override fun getEnabledProtocols(): Array<String> = asyncTls.getEnabledProtocols()
-    override fun getApplicationProtocol(): String? = null
+    override fun getApplicationProtocol(): String? = asyncTls.getApplicationProtocol()
 
     override fun getSoTimeout() = impl.getOption(SO_TIMEOUT) as Int
     override fun setSoTimeout(timeout: Int) = impl.setOption(SO_TIMEOUT, timeout)

--- a/ziti/src/main/kotlin/org/openziti/net/nio/AsyncTLSChannelSocket.kt
+++ b/ziti/src/main/kotlin/org/openziti/net/nio/AsyncTLSChannelSocket.kt
@@ -59,13 +59,13 @@ class AsyncTLSChannelSocket(transport: AsynchronousSocketChannel, host: String, 
 
     override fun setSSLParameters(params: SSLParameters) = asyncTls.setSSLParameters(params)
 
-    override fun getEnabledCipherSuites(): Array<String> = asyncTls.getEnabledCipherSuites()
-    override fun getSupportedCipherSuites(): Array<String> = asyncTls.getSupportedCipherSuites()
+    override fun getEnabledCipherSuites(): Array<String>? = asyncTls.getEnabledCipherSuites()
+    override fun getSupportedCipherSuites(): Array<String>? = asyncTls.getSupportedCipherSuites()
     override fun setEnabledCipherSuites(p: Array<String>) = asyncTls.setEnabledCipherSuites(p)
 
-    override fun getSupportedProtocols(): Array<String> = asyncTls.getSupportedProtocols()
+    override fun getSupportedProtocols(): Array<String>? = asyncTls.getSupportedProtocols()
     override fun setEnabledProtocols(p: Array<String>) = asyncTls.setEnabledProtocols(p)
-    override fun getEnabledProtocols(): Array<String> = asyncTls.getEnabledProtocols()
+    override fun getEnabledProtocols(): Array<String>? = asyncTls.getEnabledProtocols()
     override fun getApplicationProtocol(): String? = asyncTls.getApplicationProtocol()
 
     override fun getSoTimeout() = impl.getOption(SO_TIMEOUT) as Int


### PR DESCRIPTION
- AsyncTLSChannel now supports ALPN extension
- consolidate TLS read logic into a single loop
- Ziti Controller client can use HTTP/2 for better performance
