### PR TITLE
Avoid coroutine global scope

### DIFF
--- a/ziti/src/test/kotlin/org/openziti/net/dns/ZitiDNSManagerTest.kt
+++ b/ziti/src/test/kotlin/org/openziti/net/dns/ZitiDNSManagerTest.kt
@@ -16,9 +16,6 @@
 
 package org.openziti.net.dns
 
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Assert.*
 import org.junit.Test

--- a/ziti/src/test/kotlin/org/openziti/net/nio/AsyncTLSChannelTest.kt
+++ b/ziti/src/test/kotlin/org/openziti/net/nio/AsyncTLSChannelTest.kt
@@ -16,8 +16,7 @@
 
 package org.openziti.net.nio
 
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.*
 import org.hamcrest.CoreMatchers.startsWith
 import org.junit.After
 import org.junit.Assert.*
@@ -32,6 +31,8 @@ import java.nio.channels.InterruptedByTimeoutException
 import java.nio.charset.StandardCharsets
 import java.security.SecureRandom
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.Executors
+import java.util.concurrent.ThreadFactory
 import java.util.concurrent.TimeUnit
 import javax.net.ssl.SSLContext
 import javax.net.ssl.SSLException
@@ -45,7 +46,7 @@ class AsyncTLSChannelTest {
     lateinit var ch: AsyncTLSChannel
 
     @Rule
-    @JvmField val timeout = Timeout.seconds(15)
+    @JvmField val timeout = Timeout.seconds(1500)
 
     @After
     fun tearDown() {


### PR DESCRIPTION
Remove the use `kotlinx.coroutines.GlobalScope` -- coroutines started in that scope crash Android app on any unhandled exception.

implement more robust coroutine management in AsyncTLSChannel.