### PR TITLE
Normalizing hostnames when entries are added to ZitiDNSManager

### DIFF
--- a/ziti/src/main/kotlin/org/openziti/net/dns/ZitiDNSManager.kt
+++ b/ziti/src/main/kotlin/org/openziti/net/dns/ZitiDNSManager.kt
@@ -48,7 +48,7 @@ internal object ZitiDNSManager : DNSResolver, CoroutineScope {
         val ip = when {
             IPAddress.isValidIPv4(hostname) -> Inet4Address.getByName(hostname)
             IPAddress.isValidIPv6(hostname) -> Inet6Address.getByName(hostname)
-            else -> host2Ip.getOrPut(hostname) { nextAddr(hostname) }
+            else -> host2Ip.getOrPut(hostname.lowercase()) { nextAddr(hostname) }
         }
         launch {
             dnsBroadCast.emit(DNSResolver.DNSEvent(hostname, ip, false))

--- a/ziti/src/test/kotlin/org/openziti/net/dns/ZitiDNSManagerTest.kt
+++ b/ziti/src/test/kotlin/org/openziti/net/dns/ZitiDNSManagerTest.kt
@@ -38,11 +38,11 @@ class ZitiDNSManagerTest {
             block.countDown()
         }
 
-        ZitiDNSManager.registerHostname("test.dns.ziti")
+        ZitiDNSManager.registerHostname("Test.dns.ziti")
 
         assertTrue(block.await(10, TimeUnit.SECONDS))
         assertEquals(1, events.size)
-        assertEquals("test.dns.ziti", events.first().hostname)
+        assertEquals("Test.dns.ziti", events.first().hostname)
         assertFalse(events.first().removed)
         assertArrayEquals(byteArrayOf(100.toByte(), 64.toByte(), 1, 2), events.first().ip.address)
     }
@@ -59,6 +59,23 @@ class ZitiDNSManagerTest {
         }
 
         assertTrue(block.await(1, TimeUnit.SECONDS))
+    }
 
+    @Test
+    fun testResolveNormalization() {
+        ZitiDNSManager.registerHostname("TEST.dns.ziti")
+        ZitiDNSManager.registerHostname("test2.dns.ziti")
+
+        val addr1 = ZitiDNSManager.resolve("test.dns.ziti")
+        val addr2 = ZitiDNSManager.resolve("TEST2.dns.ziti")
+        val addr3 = ZitiDNSManager.resolve("does not exist")
+
+        assertNotNull(addr1);
+        assertEquals("TEST.dns.ziti", addr1?.getHostName())
+
+        assertNotNull(addr2);
+        assertEquals("test2.dns.ziti", addr2?.getHostName())
+
+        assertNull(addr3);
     }
 }


### PR DESCRIPTION
This appears to be a bug in the java SDK - hostnames are not normalized when stored in the internal host2IP map, but queries lowercase() hosts before searching.