### PR TITLE
Adding isSeamless check to Ziti.  

### DIFF
--- a/ziti/src/main/kotlin/org/openziti/Ziti.kt
+++ b/ziti/src/main/kotlin/org/openziti/Ziti.kt
@@ -73,6 +73,9 @@ object Ziti {
     @JvmStatic
     fun init(ks: KeyStore, seamless: Boolean) =  ZitiImpl.init(ks, seamless)
 
+    @JvmStatic
+    fun isSeamless() = ZitiImpl.isSeamless()
+
     fun identityEvents(): Flow<IdentityEvent> = ZitiImpl.getEvents()
 
     @JvmStatic

--- a/ziti/src/main/kotlin/org/openziti/impl/ZitiImpl.kt
+++ b/ziti/src/main/kotlin/org/openziti/impl/ZitiImpl.kt
@@ -117,6 +117,8 @@ internal object ZitiImpl : Logged by ZitiLog() {
         }
     }
 
+    fun isSeamless(): Boolean = Sockets.isInitialized()
+
     private fun initInternalNetworking() {
         Sockets.init()
     }

--- a/ziti/src/main/kotlin/org/openziti/net/internal/Sockets.kt
+++ b/ziti/src/main/kotlin/org/openziti/net/internal/Sockets.kt
@@ -40,5 +40,7 @@ internal object Sockets : Logged by ZitiLog() {
             }
         }
     }
+
+    fun isInitialized() = initialized.get()
 }
 


### PR DESCRIPTION
Returns true if Ziti was initialized with seamless = true

Will be used by the ZDBC shim to see if Ziti is seamless when the shim requires it. 