### PR TITLE
Bypassing IP resolution when hostname is present

### DIFF
--- a/ziti/src/main/kotlin/org/openziti/impl/ZitiContextImpl.kt
+++ b/ziti/src/main/kotlin/org/openziti/impl/ZitiContextImpl.kt
@@ -377,12 +377,14 @@ internal class ZitiContextImpl(internal val id: Identity, enabled: Boolean) : Zi
 
     }
     private fun getDnsTarget(addr: InetSocketAddress): String? {
-        if (addr.hostString == null && addr.address != null) {
-            return ZitiDNSManager.lookup(addr.address)
-        } else if (IPUtil.isValidIPv4(addr.hostString)) {
-            return null
+        if (addr.hostString != null ) {
+            if (IPUtil.isValidIPv4(addr.hostString)) {
+                return null
+            } else {
+                return addr.hostString
+            }
         } else {
-            return addr.hostString
+            return ZitiDNSManager.lookup(addr.address)
         }
     }
 

--- a/ziti/src/main/kotlin/org/openziti/impl/ZitiContextImpl.kt
+++ b/ziti/src/main/kotlin/org/openziti/impl/ZitiContextImpl.kt
@@ -377,7 +377,7 @@ internal class ZitiContextImpl(internal val id: Identity, enabled: Boolean) : Zi
 
     }
     private fun getDnsTarget(addr: InetSocketAddress): String? {
-        if (addr.address != null) {
+        if (addr.hostString == null && addr.address != null) {
             return ZitiDNSManager.lookup(addr.address)
         } else if (IPUtil.isValidIPv4(addr.hostString)) {
             return null


### PR DESCRIPTION
Seamless mode is failing to intercept dial requests when the host is resolvable outsize of Ziti.  The ZitiDNSManager.lookup checks the InetSocketAddress against the list of known Ziti InetSocketAddress.  The check fails, and no name-based ZitiDNS-based lookup is done when the public IP and the Ziti internal IP addresses are different.

This is probably a naive approach,  but it's what I've got.