### PR TITLE
Reduce log level for repetitive status message, improve log configuration with package naming

### DIFF
--- a/samples/ziti-spring-boot/README.md
+++ b/samples/ziti-spring-boot/README.md
@@ -1,5 +1,13 @@
 # Getting Started
 
+
+This is an example of how to use the Spring Boot integration for Ziti.
+
+It provides a simple "hello world" HTTP endpoint as a Ziti service.
+
+Check application.properties for configuration options (you need to set up at least the identity file and the service name).
+
+
 ### Reference Documentation
 
 For further reference, please consider the following sections:

--- a/samples/ziti-spring-boot/src/main/resources/application.properties
+++ b/samples/ziti-spring-boot/src/main/resources/application.properties
@@ -14,4 +14,17 @@
 # limitations under the License.
 #
 
+# This is a path pointing to the Ziti identity file to use
+ziti.id = /path/to/identity
 
+# This is the Ziti service name the application will bind to
+# You need to set up the service in Ziti and have a bind policy in place for the above identity
+ziti.serviceName = spring-boot-sample
+
+
+# Configure logging
+#
+# Ziti uses the "org.openziti" prefix for its logger names.
+# INFO is a good default, set it to DEBUG or TRACE for troubleshooting
+
+logging.level.org.openziti = INFO

--- a/ziti/src/main/kotlin/org/openziti/impl/ZitiContextImpl.kt
+++ b/ziti/src/main/kotlin/org/openziti/impl/ZitiContextImpl.kt
@@ -325,7 +325,7 @@ internal class ZitiContextImpl(internal val id: Identity, enabled: Boolean) : Zi
 
             controller.runCatching { getEdgeRouters() }
                 .onSuccess {
-                    i{"current edge routers = $it"}
+                    d{"current edge routers = $it"}
                     currentEdgeRouters.value = it }
                 .onFailure { w("failed to get current edge routers: $it") }
 

--- a/ziti/src/main/kotlin/org/openziti/util/Log.kt
+++ b/ziti/src/main/kotlin/org/openziti/util/Log.kt
@@ -45,7 +45,7 @@ interface Logged {
 
 class ZitiLog(name: String, private val delegate: Logged = SLF4JLoggedImpl(name)) : Logged by delegate {
     constructor() :
-            this(getCaller().split(".").last())
+            this(getCaller())
 
     companion object {
         fun getCaller(): String {


### PR DESCRIPTION
This should fix #311 

- reduce the log level for the offending message from INFO to DEBUG (so that it will not appear anymore in most default setup)
- use package name in logger name to allow for easier logging configuration
- update Spring Boot sample code with documentation on how to configure logging (as well as identity file and service bind)