### PR TITLE
provide version of getService by host and port that waits until it is ready, fixes #304

### DIFF
--- a/ziti/src/main/kotlin/org/openziti/ZitiContext.kt
+++ b/ziti/src/main/kotlin/org/openziti/ZitiContext.kt
@@ -73,6 +73,7 @@ interface ZitiContext: Identity {
     fun getService(addr: InetSocketAddress): Service?
     fun getService(name: String): Service?
     fun getService(name: String, timeout: Long): Service
+    fun getService(addr: InetSocketAddress, timeout: Long): Service
     fun getServiceTerminators(service: Service): Collection<ServiceTerminator>
 
     /**


### PR DESCRIPTION
This uses the same mechanism as the existing method to wait for a service by name: It first checks if it is already present, if not, it subscribes to the change stream and returns a matching service once it becomes available