### PR TITLE
ziti-spring-boot-client improvements to ZitiConnectionSocketFactory and fix for #557

### DIFF
--- a/ziti-springboot-client/src/main/java/org/openziti/springboot/client/web/httpclient/AbstractZitiConnectionSocketFactory.java
+++ b/ziti-springboot-client/src/main/java/org/openziti/springboot/client/web/httpclient/AbstractZitiConnectionSocketFactory.java
@@ -104,6 +104,10 @@ public abstract class AbstractZitiConnectionSocketFactory implements ConnectionS
     }
   }
 
+  public AbstractZitiConnectionSocketFactory(ZitiContext ctx) {
+    this.ctx = ctx;
+  }
+
   public void shutdown() {
     Optional.ofNullable(getCtx()).ifPresent(ZitiContext::destroy);
   }

--- a/ziti-springboot-client/src/main/java/org/openziti/springboot/client/web/httpclient/ZitiConnectionSocketFactory.java
+++ b/ziti-springboot-client/src/main/java/org/openziti/springboot/client/web/httpclient/ZitiConnectionSocketFactory.java
@@ -26,6 +26,7 @@ import org.apache.hc.core5.http.HttpHost;
 import org.apache.hc.core5.http.protocol.HttpContext;
 import org.apache.hc.core5.util.TimeValue;
 import org.openziti.Ziti;
+import org.openziti.ZitiContext;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -73,6 +74,10 @@ public class ZitiConnectionSocketFactory extends AbstractZitiConnectionSocketFac
   }
   public ZitiConnectionSocketFactory(String fileName, char[] pwd, long waitTime) {
     super(fileName, pwd, waitTime);
+  }
+
+  public ZitiConnectionSocketFactory(ZitiContext ctx) {
+    super(ctx);
   }
 
   @Override

--- a/ziti-springboot-client/src/main/java/org/openziti/springboot/client/web/httpclient/ZitiSSLConnectionSocketFactory.java
+++ b/ziti-springboot-client/src/main/java/org/openziti/springboot/client/web/httpclient/ZitiSSLConnectionSocketFactory.java
@@ -32,6 +32,7 @@ import org.apache.hc.core5.http.protocol.HttpContext;
 import org.apache.hc.core5.ssl.SSLContextBuilder;
 import org.apache.hc.core5.util.TimeValue;
 import org.openziti.Ziti;
+import org.openziti.ZitiContext;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -79,6 +80,10 @@ public class ZitiSSLConnectionSocketFactory extends AbstractZitiConnectionSocket
   }
   public ZitiSSLConnectionSocketFactory(String fileName, char[] pwd, long waitTime) {
     super(fileName, pwd, waitTime);
+  }
+
+  public ZitiSSLConnectionSocketFactory(ZitiContext ctx) {
+    super(ctx);
   }
 
   @Override


### PR DESCRIPTION
Fixed #557 with the response timeout using the incorrect units
Added convenience constructor to ZitiConnectionSocketFactory for referencing an existing ZitiContext