### PR TITLE
Revert ziti-springboot and ziti-springboot-client spring boot dependency to 3.1.9

### DIFF
--- a/ziti-springboot-client/build.gradle
+++ b/ziti-springboot-client/build.gradle
@@ -22,7 +22,7 @@ plugins {
 
 ext {
     description "Ziti adapter for Spring Boot Client(s)"
-    springbootVersion = '3.2.3'
+    springbootVersion = '3.1.9'
 }
 
 repositories {

--- a/ziti-springboot/build.gradle
+++ b/ziti-springboot/build.gradle
@@ -25,7 +25,7 @@ plugins {
 
 ext {
     description "Ziti adapter for Spring Boot"
-    springbootVersion = '3.2.3'
+    springbootVersion = '3.1.9'
 }
 
 repositories {


### PR DESCRIPTION
Reverted to spring boot 3.1.9 to mitigate an issue with lazysodium's resource loader and spring boot 3.2
