### PR TITLE
Ziti socket timeout stall 

### DIFF
--- a/ziti/build.gradle.kts
+++ b/ziti/build.gradle.kts
@@ -135,6 +135,7 @@ testing {
         val integrationTest by registering(JvmTestSuite::class) {
             dependencies {
                 implementation(libs.kotlin.test)
+                implementation(libs.kotlin.coroutines.lib)
                 implementation(libs.kotlin.coroutines.test)
                 implementation(libs.slf4j.simple)
                 implementation(project(":management-api"))
@@ -172,7 +173,7 @@ tasks.register("start-quickstart") {
         val pb = ProcessBuilder().apply {
             command(
                 zitiCLI.toString(),
-                "edge", "quickstart", "--home", quickstartHome.asFile.absolutePath)
+                "edge", "quickstart", "--verbose", "--home", quickstartHome.asFile.absolutePath)
             redirectOutput(qsLog)
             redirectError(errLog)
         }

--- a/ziti/src/integrationTest/kotlin/org/openziti/api/ControllerTests.kt
+++ b/ziti/src/integrationTest/kotlin/org/openziti/api/ControllerTests.kt
@@ -42,6 +42,7 @@ class ControllerTests: BaseTest() {
         appVersion = System.nanoTime().toString()
         Ziti.setApplicationInfo(info.displayName, appVersion)
 
+        idName = "id-${info.displayName}-${System.nanoTime()}"
         cfg = createIdentity(idName)
     }
 

--- a/ziti/src/integrationTest/kotlin/org/openziti/api/ControllerTests.kt
+++ b/ziti/src/integrationTest/kotlin/org/openziti/api/ControllerTests.kt
@@ -42,13 +42,7 @@ class ControllerTests: BaseTest() {
         appVersion = System.nanoTime().toString()
         Ziti.setApplicationInfo(info.displayName, appVersion)
 
-        idName = "id-${info.displayName}-${System.nanoTime()}"
-        val token = createIdentity(idName)
-
-        val enrollment = Ziti.createEnrollment(token)
-        assertEquals(enrollment.getMethod(), Enrollment.Method.ott)
-
-        cfg = enrollment.enroll()
+        cfg = createIdentity(idName)
     }
 
     @Test

--- a/ziti/src/integrationTest/kotlin/org/openziti/integ/BaseTest.kt
+++ b/ziti/src/integrationTest/kotlin/org/openziti/integ/BaseTest.kt
@@ -16,8 +16,12 @@
 
 package org.openziti.integ
 
+import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.TestInfo
+import org.openziti.Enrollment
+import org.openziti.IdentityConfig
+import org.openziti.Ziti
 
 abstract class BaseTest {
     protected lateinit var info: TestInfo
@@ -27,4 +31,12 @@ abstract class BaseTest {
         info = testInfo
     }
 
+    fun createIdentity(name: String = "id-${info.displayName}-${System.nanoTime()}"): IdentityConfig {
+        val token = ManagementHelper.createIdentity(name)
+
+        val enrollment = Ziti.createEnrollment(token)
+        Assertions.assertEquals(enrollment.getMethod(), Enrollment.Method.ott)
+
+        return enrollment.enroll()
+    }
 }

--- a/ziti/src/integrationTest/kotlin/org/openziti/net/ConnectionTests.kt
+++ b/ziti/src/integrationTest/kotlin/org/openziti/net/ConnectionTests.kt
@@ -167,7 +167,7 @@ class ConnectionTests: BaseTest() {
     }
 
     @Test
-    fun `test socket-connect-read-timeout`() = runTest(timeout = 10.seconds) {
+    fun `test socket-connect-read-timeout`() = runTest(timeout = 1000.seconds) {
         val greeting = "Hello from Ziti".toByteArray()
         val s = assertDoesNotThrow {
             ztx.serviceUpdates().filter { it.service.name == service }.first().service
@@ -195,6 +195,7 @@ class ConnectionTests: BaseTest() {
             }
 
             ztx.connect(hostname, port).use { clt ->
+                assertTrue(clt.isConnected)
                 val buf = ByteArray(1024)
                 clt.soTimeout = 500
                 val input = clt.getInputStream()

--- a/ziti/src/integrationTest/kotlin/org/openziti/net/ConnectionTests.kt
+++ b/ziti/src/integrationTest/kotlin/org/openziti/net/ConnectionTests.kt
@@ -113,7 +113,7 @@ class ConnectionTests: BaseTest() {
     }
 
     @Test
-    fun `test bind-connect-read-timeout`() = runTest(timeout = 100.seconds) {
+    fun `test bind-connect-read-timeout`() = runTest(timeout = 10.seconds) {
         val greeting = "Hello from Ziti".toByteArray()
         val s = assertDoesNotThrow {
             ztx.serviceUpdates().filter { it.service.name == service }.first().service
@@ -167,7 +167,7 @@ class ConnectionTests: BaseTest() {
     }
 
     @Test
-    fun `test socket-connect-read-timeout`() = runTest(timeout = 1000.seconds) {
+    fun `test socket-connect-read-timeout`() = runTest(timeout = 10.seconds) {
         val greeting = "Hello from Ziti".toByteArray()
         val s = assertDoesNotThrow {
             ztx.serviceUpdates().filter { it.service.name == service }.first().service

--- a/ziti/src/integrationTest/kotlin/org/openziti/net/ConnectionTests.kt
+++ b/ziti/src/integrationTest/kotlin/org/openziti/net/ConnectionTests.kt
@@ -1,0 +1,218 @@
+/*
+ * Copyright (c) 2018-2025 NetFoundry Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.openziti.net
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import org.junit.jupiter.api.*
+import org.openziti.IdentityConfig
+import org.openziti.Ziti
+import org.openziti.ZitiAddress
+import org.openziti.ZitiContext
+import org.openziti.api.DNSName
+import org.openziti.api.InterceptConfig
+import org.openziti.api.InterceptV1Cfg
+import org.openziti.api.PortRange
+import org.openziti.edge.model.DialBind
+import org.openziti.integ.BaseTest
+import org.openziti.integ.ManagementHelper
+import org.openziti.net.nio.acceptSuspend
+import org.openziti.net.nio.readSuspend
+import org.openziti.net.nio.writeSuspend
+import java.net.ConnectException
+import java.net.InetSocketAddress
+import java.net.SocketTimeoutException
+import java.nio.ByteBuffer
+import java.nio.channels.InterruptedByTimeoutException
+import java.util.concurrent.ExecutionException
+import java.util.concurrent.TimeUnit
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
+
+class ConnectionTests: BaseTest() {
+
+    private val hostname = "test${System.nanoTime()}.ziti"
+    private val port = 5000
+    private lateinit var service: String
+    private lateinit var cfg: IdentityConfig
+    private lateinit var ztx: ZitiContext
+
+    @BeforeEach
+    fun before() {
+        service = ManagementHelper.createService(
+            configs = mapOf(
+                InterceptV1Cfg to InterceptConfig(
+                    protocols = setOf(Protocol.TCP),
+                    addresses = setOf(DNSName(hostname)),
+                    portRanges = sortedSetOf(PortRange(port, port)),
+                )
+            )
+        )
+        cfg = createIdentity()
+        ztx = Ziti.newContext(cfg)
+    }
+
+    @AfterEach
+    fun after() {
+        ztx.destroy()
+    }
+
+    @Test
+    fun `test dial without terminator`() = runTest(timeout = 10.seconds) {
+        val srv = assertDoesNotThrow {
+            ztx.serviceUpdates().filter { it.service.name == service }.first().service
+        }
+
+        assertFalse(srv.config.isEmpty())
+        assertThrows<ConnectException> {
+            ztx.dial(service)
+        }.run {
+            assert(message!!.contains("has no terminators"))
+        }
+
+        assertThrows<ExecutionException> {
+            val ch = ztx.open()
+            ch.connect(ZitiAddress.Dial(service)).get()
+        }.run {
+            assert(cause!!.message!!.contains("has no terminators"))
+        }
+        assertThrows<ExecutionException> {
+            val ch = ztx.open()
+            ch.connect(InetSocketAddress.createUnresolved(hostname, port)).get()
+        }.run {
+            assert(cause!!.message!!.contains("has no terminators"))
+        }
+
+        assertThrows<ConnectException> {
+            ztx.connect(hostname, port)
+        }.run {
+            assertTrue(message!!.contains("has no terminators"))
+        }
+    }
+
+    @Test
+    fun `test bind-connect-read-timeout`() = runTest(timeout = 100.seconds) {
+        val greeting = "Hello from Ziti".toByteArray()
+        val s = assertDoesNotThrow {
+            ztx.serviceUpdates().filter { it.service.name == service }.first().service
+        }
+        assertTrue(s.permissions.contains(DialBind.DIAL))
+        assertTrue(s.permissions.contains(DialBind.BIND))
+
+        ztx.openServer().use { srv ->
+
+            srv.bind(ZitiAddress.Bind(service))
+
+            // wait for binding -- test dispatcher skips delays
+            withContext(Dispatchers.Default) {
+                val zrv = srv as ZitiServerSocketChannel
+                while (zrv.state != ZitiServerSocketChannel.State.bound) {
+                    delay(50)
+                }
+            }
+
+            launch(Dispatchers.IO) {
+                val c = srv.acceptSuspend()
+                c.writeSuspend(ByteBuffer.wrap(greeting))
+                delay(1000)
+                c.close()
+            }
+
+            ztx.open().use { clt ->
+                clt.connect(ZitiAddress.Dial(service)).get(1, TimeUnit.SECONDS)
+
+                val buf = ByteBuffer.allocate(1024)
+
+                // read 1: return greeting
+                val read1 = clt.readSuspend(buf, 100, TimeUnit.MILLISECONDS)
+                assertEquals(read1, greeting.size)
+                val readMsg = ByteArray(read1)
+                buf.flip().get(readMsg)
+                assertContentEquals(greeting, readMsg)
+                assertFalse(buf.hasRemaining())
+
+                buf.clear()
+                // read 2: should time out
+                assertThrows<InterruptedByTimeoutException> {
+                    clt.readSuspend(buf, 600, TimeUnit.MILLISECONDS)
+                }
+
+                buf.clear()
+                // read 3: should get EOF
+                assertEquals(-1, clt.readSuspend(buf, 600, TimeUnit.MILLISECONDS))
+            }
+        }
+    }
+
+    @Test
+    fun `test socket-connect-read-timeout`() = runTest(timeout = 10.seconds) {
+        val greeting = "Hello from Ziti".toByteArray()
+        val s = assertDoesNotThrow {
+            ztx.serviceUpdates().filter { it.service.name == service }.first().service
+        }
+        assertTrue(s.permissions.contains(DialBind.DIAL))
+        assertTrue(s.permissions.contains(DialBind.BIND))
+
+        ztx.openServer().use { srv ->
+
+            srv.bind(ZitiAddress.Bind(service))
+
+            // wait for binding -- test dispatcher skips delays
+            withContext(Dispatchers.Default) {
+                val zrv = srv as ZitiServerSocketChannel
+                while (zrv.state != ZitiServerSocketChannel.State.bound) {
+                    delay(50)
+                }
+            }
+
+            launch(Dispatchers.IO) {
+                val c = srv.acceptSuspend()
+                c.writeSuspend(ByteBuffer.wrap(greeting))
+                val b = ByteBuffer.allocate(1024)
+                c.readSuspend(b)
+            }
+
+            ztx.connect(hostname, port).use { clt ->
+                val buf = ByteArray(1024)
+                clt.soTimeout = 500
+                val input = clt.getInputStream()
+
+                // read 1: return greeting
+                val read1 = input.read(buf)
+                assertEquals(read1, greeting.size)
+                val readMsg = buf.sliceArray(0..<read1)
+                assertContentEquals(greeting, readMsg)
+
+                // other reads would get a timeout
+                for (i in 0 .. 10) {
+                    assertThrows<SocketTimeoutException> {
+                        input.read(buf)
+                    }
+                }
+            }
+        }
+    }
+
+}

--- a/ziti/src/main/kotlin/org/openziti/api/Controller.kt
+++ b/ziti/src/main/kotlin/org/openziti/api/Controller.kt
@@ -46,6 +46,10 @@ import kotlin.reflect.full.memberFunctions
 internal class Controller(endpoint: String, sslContext: SSLContext):
     Logged by ZitiLog() {
 
+    companion object {
+        val ALL_CONFIGS = listOf("all")
+    }
+
     private val pageSize = 100
 
     private val http = HttpClient.newBuilder()
@@ -142,7 +146,7 @@ internal class Controller(endpoint: String, sslContext: SSLContext):
 
         return pagingApiRequest {
                 limit, offset -> serviceApi.listServices(limit,  offset,
-            null, listOf("all"), null, null)
+            null, ALL_CONFIGS, null, null)
         }
     }
 
@@ -277,7 +281,7 @@ internal class Controller(endpoint: String, sslContext: SSLContext):
             .os(info.os)
             .osRelease(info.osRelease)
             .osVersion(info.osVersion)
-        configTypes = listOf("#all")
+        configTypes = ALL_CONFIGS
     }
 
     internal inner class ReqInterceptor(val session: ApiSession? = null): Consumer<HttpRequest.Builder> {

--- a/ziti/src/main/kotlin/org/openziti/api/Controller.kt
+++ b/ziti/src/main/kotlin/org/openziti/api/Controller.kt
@@ -142,7 +142,7 @@ internal class Controller(endpoint: String, sslContext: SSLContext):
 
         return pagingApiRequest {
                 limit, offset -> serviceApi.listServices(limit,  offset,
-            null, null, null, null)
+            null, listOf("all"), null, null)
         }
     }
 
@@ -277,7 +277,7 @@ internal class Controller(endpoint: String, sslContext: SSLContext):
             .os(info.os)
             .osRelease(info.osRelease)
             .osVersion(info.osVersion)
-        configTypes = listOf(InterceptV1Cfg, ClientV1Cfg)
+        configTypes = listOf("#all")
     }
 
     internal inner class ReqInterceptor(val session: ApiSession? = null): Consumer<HttpRequest.Builder> {

--- a/ziti/src/main/kotlin/org/openziti/api/types.kt
+++ b/ziti/src/main/kotlin/org/openziti/api/types.kt
@@ -16,6 +16,7 @@
 
 package org.openziti.api
 
+import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.kotlinModule
 import org.openziti.edge.model.CurrentApiSessionDetail
@@ -27,12 +28,6 @@ import java.util.*
 internal const val ClientV1Cfg = "ziti-tunneler-client.v1"
 internal const val InterceptV1Cfg = "intercept.v1"
 typealias SessionType = org.openziti.edge.model.DialBind
-
-enum class InterceptProtocol {
-    tcp,
-    udp,
-    sctp
-}
 
 internal class Login(val username: String, val password: String)
 typealias ApiSession = CurrentApiSessionDetail
@@ -57,10 +52,16 @@ data class InterceptConfig(
     val addresses: Set<InterceptAddress>,
     val portRanges: SortedSet<PortRange>,
     val dialOptions: Map<String,Any> = emptyMap(),
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     val sourceIp: String? = null
 ) {
     override fun toString(): String {
         return """${protocols.display()}:${addresses.display()}:${portRanges.display()}"""
+    }
+
+    fun matches(host: String, port: Int): Boolean {
+        return addresses.any { it.matches(host) } &&
+                portRanges.any { r -> port in r.low..r.high }
     }
 }
 

--- a/ziti/src/main/kotlin/org/openziti/identity/Enroller.kt
+++ b/ziti/src/main/kotlin/org/openziti/identity/Enroller.kt
@@ -201,6 +201,9 @@ internal class Enroller(
             ControllersApi(api).listControllers(10, 0, null)
         }.get(3, TimeUnit.SECONDS)
 
+        if (resp.data.isEmpty())
+            return listOf(ctrl)
+
         return resp.data.mapNotNull { it.apiAddresses?.get("edge-client") }.flatten()
             .filter {it.version == "v1" }.mapNotNull { it.url }
     }

--- a/ziti/src/main/kotlin/org/openziti/impl/ZitiContextImpl.kt
+++ b/ziti/src/main/kotlin/org/openziti/impl/ZitiContextImpl.kt
@@ -214,16 +214,17 @@ internal class ZitiContextImpl(internal val id: Identity, enabled: Boolean) : Zi
 
     override fun connect(host: String, port: Int): Socket {
         checkEnabled()
-        val ch = open()
-        runCatching {
+        return runCatching {
+            val ch = open()
             ch.connect(InetSocketAddress.createUnresolved(host, port)).get(10, TimeUnit.SECONDS)
-        }.onFailure {
+            d { "connected: ${ch.remoteAddress}" }
+            AsychChannelSocket(ch)
+        }.getOrElse {
             when (it) {
                 is ExecutionException -> throw it.cause ?: it
                 else -> throw it
             }
         }
-        return AsychChannelSocket(ch)
     }
 
     fun start(): Job = launch {

--- a/ziti/src/main/kotlin/org/openziti/impl/ZitiContextImpl.kt
+++ b/ziti/src/main/kotlin/org/openziti/impl/ZitiContextImpl.kt
@@ -19,36 +19,34 @@ package org.openziti.impl
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.future.asCompletableFuture
 import kotlinx.coroutines.selects.select
 import org.openziti.*
+import org.openziti.Identity
 import org.openziti.ZitiException.Errors
 import org.openziti.api.*
 import org.openziti.edge.model.*
-import org.openziti.Identity
 import org.openziti.net.*
 import org.openziti.net.Protocol
 import org.openziti.net.dns.ZitiDNSManager
+import org.openziti.net.nio.AsychChannelSocket
 import org.openziti.net.nio.connectSuspend
 import org.openziti.net.routing.RouteManager
 import org.openziti.posture.PostureService
 import org.openziti.util.IPUtil
 import org.openziti.util.Logged
 import org.openziti.util.ZitiLog
-import java.io.Closeable
 import java.io.Writer
 import java.net.*
 import java.nio.channels.AsynchronousServerSocketChannel
 import java.nio.channels.AsynchronousSocketChannel
 import java.time.OffsetDateTime
-import java.util.concurrent.CompletionStage
-import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.Future
-import java.util.concurrent.TimeUnit
-import java.util.concurrent.TimeoutException
+import java.util.concurrent.*
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.function.Consumer
 import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.cancellation.CancellationException
 import kotlin.properties.Delegates
 import kotlin.random.Random
 import kotlin.time.DurationUnit
@@ -216,10 +214,16 @@ internal class ZitiContextImpl(internal val id: Identity, enabled: Boolean) : Zi
 
     override fun connect(host: String, port: Int): Socket {
         checkEnabled()
-        getService(host, port, 10000L) // throws timeout exception if no service loaded
-        val sock = ZitiSocketFactory(this).createSocket()
-        sock.connect(InetSocketAddress.createUnresolved(host, port))
-        return sock
+        val ch = open()
+        runCatching {
+            ch.connect(InetSocketAddress.createUnresolved(host, port)).get(10, TimeUnit.SECONDS)
+        }.onFailure {
+            when (it) {
+                is ExecutionException -> throw it.cause ?: it
+                else -> throw it
+            }
+        }
+        return AsychChannelSocket(ch)
     }
 
     fun start(): Job = launch {
@@ -515,11 +519,7 @@ internal class ZitiContextImpl(internal val id: Identity, enabled: Boolean) : Zi
                 withTimeout(timeout) {
                     serviceUpdates().filter {
                         it.type == ZitiContext.ServiceUpdate.Available &&
-                            servicesByName.get(it.service.name)?.let { svc ->
-                                svc.interceptConfig()?.let {
-                                    it.addresses.any { it.matches(host) } && it.portRanges.any { r -> port in r.low..r.high }
-                                } ?: false
-                            } ?: false
+                                (it.service.interceptConfig()?.matches(host, port) ?: false)
                     }.first().service
                 }
             }

--- a/ziti/src/main/kotlin/org/openziti/net/DialData.kt
+++ b/ziti/src/main/kotlin/org/openziti/net/DialData.kt
@@ -16,13 +16,13 @@
 
 package org.openziti.net
 
-import com.fasterxml.jackson.annotation.JsonAlias
+import com.fasterxml.jackson.annotation.JsonProperty
 import com.google.gson.annotations.SerializedName
 
 enum class Protocol {
-    @SerializedName("tcp") @JsonAlias("tcp") TCP,
-    @SerializedName("udp") @JsonAlias("udp") UDP,
-    @SerializedName("sctp") @JsonAlias("sctp") SCTP,
+    @SerializedName("tcp") @JsonProperty("tcp") TCP,
+    @SerializedName("udp") @JsonProperty("udp") UDP,
+    @SerializedName("sctp") @JsonProperty("sctp") SCTP,
 }
 
 data class DialData(

--- a/ziti/src/main/kotlin/org/openziti/net/ZitiSocketChannel.kt
+++ b/ziti/src/main/kotlin/org/openziti/net/ZitiSocketChannel.kt
@@ -337,14 +337,14 @@ internal class ZitiSocketChannel private constructor(internal val ctx: ZitiConte
                 var data = ByteArray(b.remaining())
                 b.get(data)
 
-                crypto.getCompleted()?.let {
+                sent += data.size
+                crypto.await()?.let {
                     data = it.encrypt(data)
                 }
 
                 val dataMessage = Message(ZitiProtocol.ContentType.Data, data)
                 dataMessage.setHeader(Header.ConnId, connId)
                 dataMessage.setHeader(Header.SeqHeader, seq.getAndIncrement())
-                sent += data.size
                 v("sending $dataMessage")
                 channel.await().Send(dataMessage)
             }

--- a/ziti/src/main/kotlin/org/openziti/net/ZitiSocketChannel.kt
+++ b/ziti/src/main/kotlin/org/openziti/net/ZitiSocketChannel.kt
@@ -479,6 +479,7 @@ internal class ZitiSocketChannel private constructor(internal val ctx: ZitiConte
                 }
 
                 local = ZitiAddress.Session(ns.id, serviceName, null, null)
+                this.remote = ZitiAddress.Session(ns.id, serviceName, remote.identity, null)
                 d("network connection established ${ns.id}/$connId")
                 state.set(State.connected)
             }

--- a/ziti/src/main/kotlin/org/openziti/net/nio/AsychChannelSocket.kt
+++ b/ziti/src/main/kotlin/org/openziti/net/nio/AsychChannelSocket.kt
@@ -54,4 +54,14 @@ class AsychChannelSocket(internal val impl: AsyncSocketImpl = AsyncSocketImpl())
         connect(InetSocketAddress(address, port))
     }
 
+    override fun isConnected(): Boolean {
+        return impl.channel.remoteAddress != null
+    }
+
+    override fun isClosed(): Boolean = !impl.channel.isOpen
+
+    override fun close() {
+        impl.channel.close()
+    }
+
 }


### PR DESCRIPTION
[fixes #676] 


Test Improvements:
* Simplified the identity creation
* Added methods for creating services and managing service policies. 
* Added `ConnectionTests` to test connection scenarios, including timeout and read operations.
