### PR TITLE
Sonatype publishing migration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -104,8 +104,8 @@ subprojects {
 nexusPublishing {
     repositories {
         sonatype {
-            nexusUrl.set(uri("https://s01.oss.sonatype.org/service/local/"))
-            snapshotRepositoryUrl.set(uri("https://s01.oss.sonatype.org/content/repositories/snapshots/"))
+            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
         }
     }
 }


### PR DESCRIPTION
update publishing URLs per https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/