### PR TITLE
Fix for indexOutOfBoundsException on socket read

### DIFF
--- a/ziti/src/main/kotlin/org/openziti/net/nio/AsyncSocketImpl.kt
+++ b/ziti/src/main/kotlin/org/openziti/net/nio/AsyncSocketImpl.kt
@@ -164,7 +164,9 @@ internal class AsyncSocketImpl(private val connector: Connector = DefaultConnect
                         }
                         input.flip()
 
-                        val count = min(len, readCount.getOrElse { throwIOException(it) })
+                        val readResult = readCount.getOrElse { throwIOException(it) }
+                        if (readResult < 0) return@withLock readResult
+                        val count = min(len, readResult)
                         input.get(b, off, count)
                         count
                     }


### PR DESCRIPTION
Fix for #780 by adding a test for a negative read length